### PR TITLE
add captureSample plugin call to android module

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ ion-content {
   --background: transparent;
 }
 ```
-Take into account that this will make transparent all ion-content on application, if you want to show camera preview only in one page, just add a cutom class to your ion-content and make it transparent:
+Take into account that this will make transparent all ion-content on application, if you want to show camera preview only in one page, just add a custom class to your ion-content and make it transparent:
 
 ```css
 .my-custom-camera-preview-content {
@@ -203,7 +203,7 @@ CameraPreview.hide();
 <!-- <info>Take the picture. If width and height are not specified or are 0 it will use the defaults. If width and height are specified, it will choose a supported photo size that is closest to width and height specified and has closest aspect ratio to the preview. The argument `quality` defaults to `85` and specifies the quality/compression value: `0=max compression`, `100=max quality`.</info><br/> -->
 
 ```javascript
-import { CameraPreviewFlashMode } from 'c@capacitor-community/camera-preview';
+import { CameraPreviewFlashMode } from '@capacitor-community/camera-preview';
 
 const cameraPreviewPictureOptions: CameraPreviewPictureOptions = {
   quality: 50
@@ -222,16 +222,16 @@ const base64PictureData = result.value;
 |----------|---------------|----------------------------------------------------------------------|
 | quality  | number        | (optional) The picture quality, 0 - 100, default 85                  |
 
-<info>Captures a sample image from the video stream. This can be used to perform real-time analysis on the current frame in the video. The argument `quality` defaults to `85` and specifies the quality/compression value: `0=max compression`, `100=max quality`.</info><br/>
+<info>Captures a sample image from the video stream. Only for Android and iOS, web implementation falls back to `capture` method. This can be used to perform real-time analysis on the current frame in the video. The argument `quality` defaults to `85` and specifies the quality/compression value: `0=max compression`, `100=max quality`.</info><br/>
 
 ```javascript
-import { CameraPreviewFlashMode } from 'c@capacitor-community/camera-preview';
+import { CameraSampleOptions } from '@capacitor-community/camera-preview';
 
-const cameraPreviewPictureOptions: CameraPreviewPictureOptions = {
+const cameraSampleOptions: CameraSampleOptions = {
   quality: 50
 };
 
-const result = await CameraPreview.captureSample(cameraPreviewPictureOptions);
+const result = await CameraPreview.captureSample(cameraSampleOptions);
 const base64PictureData = result.value;
 
 // do something with base64PictureData

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ const base64PictureData = result.value;
 
 ```
 
+### captureSample(options)
+
+| Option   | values        | descriptions                                                         |
+|----------|---------------|----------------------------------------------------------------------|
+| quality  | number        | (optional) The picture quality, 0 - 100, default 85                  |
+
 ### getSupportedFlashModes()
 
 <info>Get the flash modes supported by the camera device currently started. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for possible values that can be returned</info><br/>

--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ const base64PictureData = result.value;
 |----------|---------------|----------------------------------------------------------------------|
 | quality  | number        | (optional) The picture quality, 0 - 100, default 85                  |
 
+<info>Captures a sample image from the video stream. This can be used to perform real-time analysis on the current frame in the video. The argument `quality` defaults to `85` and specifies the quality/compression value: `0=max compression`, `100=max quality`.</info><br/>
+
+```javascript
+import { CameraPreviewFlashMode } from 'c@capacitor-community/camera-preview';
+
+const cameraPreviewPictureOptions: CameraPreviewPictureOptions = {
+  quality: 50
+};
+
+const result = await CameraPreview.captureSample(cameraPreviewPictureOptions);
+const base64PictureData = result.value;
+
+// do something with base64PictureData
+
+```
+
 ### getSupportedFlashModes()
 
 <info>Get the flash modes supported by the camera device currently started. Returns an array containing supported flash modes. See <code>[FLASH_MODE](#camera_Settings.FlashMode)</code> for possible values that can be returned</info><br/>

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -93,6 +93,18 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
         fragment.takePicture(width, height, quality);
     }
 
+
+    @PluginMethod()
+    public void captureSample(PluginCall call) {
+        if(this.hasCamera(call) == false){
+            call.error("Camera is not running");
+            return;
+        }
+        saveCall(call);
+        Integer quality = call.getInt("quality", 85);
+        fragment.takeSnapshot(quality);
+    }
+
     @PluginMethod()
     public void stop(final PluginCall call) {
         bridge.getActivity().runOnUiThread(new Runnable() {
@@ -309,14 +321,9 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
     @Override
     public void onSnapshotTaken(String originalPicture) {
-        JSONArray data = new JSONArray();
-        data.put(originalPicture);
-
-        PluginCall call = getSavedCall();
-
         JSObject jsObject = new JSObject();
-        jsObject.put("result", data);
-        call.success(jsObject);
+        jsObject.put("value", originalPicture);
+        getSavedCall().success(jsObject);
     }
 
     @Override

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -7,6 +7,7 @@ CAP_PLUGIN(CameraPreview, "CameraPreview",
            CAP_PLUGIN_METHOD(start, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(capture, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(captureSample, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(flip, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getSupportedFlashModes, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setFlashMode, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -26,24 +26,16 @@ public class CameraPreview: CAPPlugin {
         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
 
         if UIDevice.current.orientation.isLandscape {
-
             self.previewView.frame = CGRect(x: self.y!, y: self.x!, width: height, height: self.width!)
             self.cameraController.previewLayer?.frame = self.previewView.frame
-
-            if (UIDevice.current.orientation == UIDeviceOrientation.landscapeLeft) {
-                self.cameraController.previewLayer?.connection?.videoOrientation = .landscapeRight
-            }
-
-            if (UIDevice.current.orientation == UIDeviceOrientation.landscapeRight) {
-                self.cameraController.previewLayer?.connection?.videoOrientation = .landscapeLeft
-            }
         }
 
         if UIDevice.current.orientation.isPortrait {
             self.previewView.frame = CGRect(x: self.x!, y: self.y!, width: self.width!, height: self.height!)
             self.cameraController.previewLayer?.frame = self.previewView.frame
-            self.cameraController.previewLayer?.connection?.videoOrientation = .portrait
         }
+
+        cameraController.updateVideoOrientation()
     }
 
     @objc func start(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -43,12 +43,19 @@ export interface CameraPreviewPictureOptions {
   /** The picture quality, 0 - 100, default 85 */
   quality?: number;
 }
+
+export interface CameraSampleOptions {
+  /** The picture quality, 0 - 100, default 85 */
+  quality?: number;
+}
+
 export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'red-eye' | 'torch';
 
 export interface CameraPreviewPlugin {
   start(options: CameraPreviewOptions): Promise<{}>;
   stop(): Promise<{}>;
   capture(options: CameraPreviewPictureOptions): Promise<{ value: string }>;
+  captureSample(options: CameraSampleOptions): Promise<{ value: string }>;
   getSupportedFlashModes(): Promise<{
     result: CameraPreviewFlashMode[]
   }>;

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,5 +1,11 @@
 import { WebPlugin } from "@capacitor/core";
-import { CameraPreviewOptions, CameraPreviewPictureOptions, CameraPreviewPlugin, CameraPreviewFlashMode } from "./definitions";
+import { 
+  CameraPreviewOptions, 
+  CameraPreviewPictureOptions, 
+  CameraPreviewPlugin, 
+  CameraPreviewFlashMode, 
+  CameraSampleOptions 
+} from "./definitions";
 
 export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
   constructor() {
@@ -86,6 +92,10 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
           .replace("data:image/png;base64,", ""),
       });
     });
+  }
+
+  async captureSample(_options: CameraSampleOptions): Promise<any> {
+    return this.capture(_options);
   }
 
   async getSupportedFlashModes(): Promise<{


### PR DESCRIPTION
## Summary of changes so far:

- Add `captureSample` plugin call to android plugin
- slightly modify the the `onSnapshotTaken` callback to have the same signature as `onPictureTaken` 
    - this removes the need for any changes to the current web project, which I like
    - this callback was previously entirely uncalled, so I don't feel bad about modifying its signature
    
## Still left to do before creating a PR on the main repo:
- Possibly include iOS changes here as well
- Modify README to talk about the new plugin call